### PR TITLE
Add a check for whether a property exists before accessing it

### DIFF
--- a/panelgroup.php
+++ b/panelgroup.php
@@ -21,7 +21,7 @@ class PanelGroupField extends BaseField {
 
     public function content_start() {
 
-        $class = ($this->accordian === true) ? 'is-accordian' : '';
+        $class = (isset($this->accordian) && $this->accordian === true) ? 'is-accordian' : '';
 
         return '<div class="field-group open '.$class.'" data-field="panelgroup" name="panelgroup" groupname="'.$this->label.'">'
         . $this->label()


### PR DESCRIPTION
This avoids a PHP notice for an undefined property. Resolves https://github.com/louiswalch/kirby-panel-group/issues/1
